### PR TITLE
Switched to Events.AnimationEnd instead of "end"

### DIFF
--- a/Animate/Trigger On End (casual).coffee
+++ b/Animate/Trigger On End (casual).coffee
@@ -6,7 +6,7 @@ layerA.onClick ->
 		properties:
 			scale: 0
 		curve: "spring(100,30,0)"
-	animationA.on 'end', ->
+	animationA.on Events.AnimationEnd, ->
 		layerB.animate
 			properties:
 				scale: 0


### PR DESCRIPTION
Keeping it consistent with the Repeating Start.coffee code and Framer Docs
